### PR TITLE
Fix CI by invoking xcode-select before installing and running Buildout

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Setup environment and run Buildout
         run: |
+          sudo xcode-select -switch /Library/Developer/CommandLineTools
           python -m pip install --upgrade pip
           pip install --upgrade wheel
           pip install --upgrade --pre "zc.buildout==${{ matrix.buildout-version }}"


### PR DESCRIPTION
What the title says. The patch fixes the issue outlined at #1, by implementing the suggestion by @mikhailkoliada at https://github.com/actions/virtual-environments/issues/5791#issuecomment-1162978454.