### PR TITLE
Explicitly select `sqlalchemy[asyncio]` for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     name='test-buildout-python310',
     version='0.0.0',
     url='https://github.com/crate-workbench/test-buildout-python310',
-    install_requires='sqlalchemy>=1.0,<1.5',
+    install_requires='sqlalchemy[asyncio]>=1.0,<1.5',
 )


### PR DESCRIPTION
What the title says. The patch follows the suggestion at https://github.com/sqlalchemy/sqlalchemy/issues/7922:

> `pip install sqlalchemy[asyncio]` should definitely install greenlet in all cases.
