### PR TITLE
Set environment variable `_PYTHON_HOST_PLATFORM=macosx-11-x86_64`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,7 @@ jobs:
       # Switches to enable compatibility with older versions of macOS.
       SYSTEM_VERSION_COMPAT: 1
       MACOSX_DEPLOYMENT_TARGET: 10.16
+      _PYTHON_HOST_PLATFORM: macosx-11-x86_64
 
     steps:
 


### PR DESCRIPTION
What the title says. The patch aims to fix the issue outlined at #1, by implementing the suggestion by @icemac at https://github.com/buildout/buildout/issues/609#issuecomment-1164001117.